### PR TITLE
be: Update to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
       Region your s3 bucket is in
     default: 'us-east-1'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
node12 is becoming deprecated, upgrade to node16

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>